### PR TITLE
fix: release versionをmanifest.jsonのみ参照に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,11 @@ jobs:
         id: meta
         run: |
           last_tag=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
-          if [ -z "$last_tag" ]; then
-            base_version=$(node -p "require('./manifest.json').version || '0.0.1'")
-            version="$base_version"
-          else
-            ver="${last_tag#v}"
-            IFS='.' read -r major minor patch <<< "$ver"
-            patch=$((patch + 1))
-            version="${major}.${minor}.${patch}"
+          version=$(node -p "require('./manifest.json').version || ''")
+          version="${version#v}"
+          if [ -z "$version" ]; then
+            echo "manifest.json version is empty" >&2
+            exit 1
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 概要
Release workflow の版数決定を `manifest.json` の `version` のみ参照するように変更しました。

## 変更内容
- `.github/workflows/release.yml` の `Prepare release metadata` を修正
- これまでの `last_tag` 起点の patch 自動加算を廃止
- `version=$(node -p "require('./manifest.json').version || ''")` を採用
- `version` が空の場合は workflow を失敗させるガードを追加

## 意図
- `manifest.json` を単一の truth source として扱い、意図しない `v0.0.x` 連番リリースを防ぐため

## 影響範囲
- Release workflow のタグ/バージョン算出処理のみ
- リリースノート生成で使う `last_tag` 取得処理は継続

## 動作確認
- ローカルで同ロジックを実行し、`manifest.json` が `0.1.1` の場合に `tag=v0.1.1` になることを確認
